### PR TITLE
Set up pulls by rarity and card slots

### DIFF
--- a/Test Card List CSV.csv
+++ b/Test Card List CSV.csv
@@ -16,3 +16,4 @@ UltraRare,UltraRare_GuildHalleyo_this_is_a_test_of_space,this is a test of space
 UltraRare,UltraRare_OMbretest_Whatiscolour,Whatiscolour,Noble,675,UwU,UwU,def,2,1,dolor,lorem text,Game,yep,2,45,xd,rawr,,,UwU,6,OMbretest,f
 Uncommon,Uncommon_AltareTEST_Slimies,Slimies,,,,,,,,,,,,,,,,is this the last one?,let me check,:3,7,AltareTEST,g
 Uncommon,Uncommon_MagniTEST_Doopdedoo,Doopdedoo,Initiate,7,Zatsu,Music,ghi,1,2,sit,here,,,,,,,,,>:3,8,MagniTEST,h
+Element,SecretRare_Rainbowwww_TheGayAgenda,TheGayAgenda,,,,,,,,,,,,,,,,"this, too, is an item",of course,:D,12,Rainbowwww,d

--- a/js/gacha.js
+++ b/js/gacha.js
@@ -2,6 +2,7 @@ import { renderCards } from "./cards.js";
 import { cards_by_rarity } from "./main.js";
 
 export const GACHA_BUTTON = document.getElementById("gacha-button");
+
 //Card slots on each pull, representing the percent chance of getting a card of that rarity in each slot.
 //The sum of all rarities on a slot should be 100 or higher for proper function.
 const slots = [
@@ -52,6 +53,7 @@ const slots = [
     SecretRare: 20,
   },
 ];
+
 //Slots that replace one or more normal slots on special conditions.
 //This can be used to help collect all cards.
 const specialSlots = {
@@ -110,7 +112,7 @@ function getRandomCards(cards, n) {
   return samples.slice(0, n);
 }
 
-//Pulls cards from the cards_data array and renders them in CARD_LIST.
+//Pulls cards from the cards_data array and renders them in render_location.
 export function pullAndRenderCards(cards_data, render_location) {
   //let pulled = getRandomCards(cards_data, n);
   let pulled = pullCards(slots);

--- a/js/gacha.js
+++ b/js/gacha.js
@@ -7,7 +7,7 @@ export const GACHA_BUTTON = document.getElementById("gacha-button");
 //The sum of all rarities on a slot should be 100 or higher for proper function.
 const slots = [
   {
-    Common: 100,
+    Element: 100,
   },
   {
     Common: 100,
@@ -21,7 +21,8 @@ const slots = [
     Uncommon: 20,
   },
   {
-    Uncommon: 100,
+    Common: 50,
+    Uncommon: 50,
   },
   {
     Uncommon: 100,
@@ -72,11 +73,25 @@ function pullCards(slots) {
     if (dice in specialSlots) {
       slot = specialSlots[dice];
     }
+    //This algorithm divides the range [1, 100] into rarity intervals, dictated by the slots.
+    //Example: A slot with the following definition:
+    //{Common: 60, Uncommon: 30, Rare: 10}
+    //In this case, if the dice value is 60 or less, the pulled card is common.
+    //Else, if it's in between 61 and 90, it is uncommon
+    //Else, if it's 91 or higher, it is rare.
+    //This applies to as many rarities as declared in the slot.
     for (let rarity in slot) {
       if (dice <= slot[rarity]) {
         cards.push(getRandomCards(cards_by_rarity[rarity], 1)[0]);
         break;
       } else {
+        //Using this we can save on having to define each interval in absolute terms,
+        //doing it in relative terms instead.
+        //Example: Instead of writing {Common: [1, 80], Uncommon: [81, 100]},
+        //we write {Common: 80, Uncommon: 20}.
+        //Then, we check if the dice falls in the first rarity. If it isn't, we "jump"
+        //over the entire interval and check on the next one, simplifying comparisons
+        //and declarations.
         dice -= slot[rarity];
       }
     }
@@ -114,7 +129,6 @@ function getRandomCards(cards, n) {
 
 //Pulls cards from the cards_data array and renders them in render_location.
 export function pullAndRenderCards(cards_data, render_location) {
-  //let pulled = getRandomCards(cards_data, n);
   let pulled = pullCards(slots);
   renderCards(pulled, render_location, true);
 }
@@ -139,7 +153,10 @@ function calculateRates(pulls) {
   return rates;
 }
 
-function testRates() {
+//If you want to see the current rates, go to your browser console and do:
+//const m = await import('../js/gacha.js');
+//m.testRates()
+export function testRates() {
   let pulls = pullCardsManyTimes(slots, 10000);
   console.log(calculateRates(pulls));
 }

--- a/js/gacha.js
+++ b/js/gacha.js
@@ -7,39 +7,45 @@ export const GACHA_BUTTON = document.getElementById("gacha-button");
 const slots = [
   {
     Common: 100,
-    Uncommon: 0,
-    Rare: 0,
-    HoloRare: 0,
-    UltraRare: 0,
-    SecretRare: 0,
+  },
+  {
+    Common: 100,
   },
   {
     Common: 80,
     Uncommon: 20,
-    Rare: 0,
-    HoloRare: 0,
-    UltraRare: 0,
-    SecretRare: 0,
   },
   {
-    Common: 0,
+    Common: 80,
+    Uncommon: 20,
+  },
+  {
     Uncommon: 100,
-    Rare: 0,
-    HoloRare: 0,
-    UltraRare: 0,
-    SecretRare: 0,
   },
   {
-    Common: 26,
+    Uncommon: 100,
+  },
+  {
     Uncommon: 26,
-    Rare: 0,
+    Rare: 26,
     HoloRare: 21,
-    UltraRare: 16,
-    SecretRare: 11,
+    UltraRare: 17,
+    SecretRare: 10,
   },
   {
-    Common: 0,
-    Uncommon: 0,
+    Uncommon: 26,
+    Rare: 26,
+    HoloRare: 21,
+    UltraRare: 17,
+    SecretRare: 10,
+  },
+  {
+    Rare: 40,
+    HoloRare: 20,
+    UltraRare: 20,
+    SecretRare: 20,
+  },
+  {
     Rare: 40,
     HoloRare: 20,
     UltraRare: 20,
@@ -50,9 +56,6 @@ const slots = [
 //This can be used to help collect all cards.
 const specialSlots = {
   69: {
-    Common: 0,
-    Uncommon: 0,
-    Rare: 0,
     HoloRare: 100 / 3,
     UltraRare: 100 / 3,
     SecretRare: 100 / 3,
@@ -67,7 +70,7 @@ function pullCards(slots) {
     if (dice in specialSlots) {
       slot = specialSlots[dice];
     }
-    for (let rarity in cards_by_rarity) {
+    for (let rarity in slot) {
       if (dice <= slot[rarity]) {
         cards.push(getRandomCards(cards_by_rarity[rarity], 1)[0]);
         break;
@@ -111,7 +114,6 @@ function getRandomCards(cards, n) {
 export function pullAndRenderCards(cards_data, render_location) {
   //let pulled = getRandomCards(cards_data, n);
   let pulled = pullCards(slots);
-  testRates();
   renderCards(pulled, render_location, true);
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,7 @@
 //Happy Birthday Leader! 🎇💙
 import { defineCardComponent, renderCards } from "./cards.js";
 import { setupDetailsDialog } from "./dialog.js";
-import { GACHA_BUTTON, CARDS_PER_PULL, pullAndRenderCards } from "./gacha.js";
+import { GACHA_BUTTON, pullAndRenderCards } from "./gacha.js";
 
 const CSV_FILENAME = "../Test Card List CSV.csv";
 const pathname = window.location.pathname;
@@ -13,6 +13,7 @@ export const CARD_ART_HIDDEN_ON_LOAD =
   PAGES_WHERE_CARD_HIDDEN.includes(CURRENT_PAGE);
 //Holds the data of all cards after parsing the CSV file.
 export let cards_data = [];
+export let cards_by_rarity = {};
 
 function getCSVData(callback = undefined) {
   Papa.parse(CSV_FILENAME, {
@@ -28,26 +29,31 @@ function getCSVData(callback = undefined) {
   });
 }
 
+function getCardsByRarity() {
+  cards_by_rarity = cards_data.reduce((result, card) => {
+    result[card["Rarity Folder"]] = [
+      ...(result[card["Rarity Folder"]] || []),
+      card,
+    ];
+    return result;
+  }, {});
+}
+
 async function main() {
   await defineCardComponent();
-  getCSVData((cards_data) => {
-    if (CURRENT_PAGE == "/collection.html") {
-      renderCards(cards_data, COLLECTIONS_MAIN_CONTENT);
+  getCSVData(async (cards_data) => {
+    switch (CURRENT_PAGE) {
+      case "/gacha.html":
+        GACHA_BUTTON.onclick = (event) =>
+          pullAndRenderCards(cards_data, COLLECTIONS_MAIN_CONTENT);
+        await setupDetailsDialog();
+        break;
+      case "/collection.html":
+        await setupDetailsDialog();
+        renderCards(cards_data, COLLECTIONS_MAIN_CONTENT);
     }
+    getCardsByRarity();
   });
-  switch (CURRENT_PAGE) {
-    case "/gacha.html":
-      GACHA_BUTTON.onclick = (event) =>
-        pullAndRenderCards(
-          cards_data,
-          CARDS_PER_PULL,
-          COLLECTIONS_MAIN_CONTENT
-        );
-      await setupDetailsDialog();
-      break;
-    case "/collection.html":
-      await setupDetailsDialog();
-  }
 }
 
 main();

--- a/js/main.js
+++ b/js/main.js
@@ -22,6 +22,7 @@ function getCSVData(callback = undefined) {
     header: true,
     complete: (result) => {
       cards_data = result.data;
+      getCardsByRarity();
       if (callback) {
         callback(cards_data);
       }
@@ -29,6 +30,15 @@ function getCSVData(callback = undefined) {
   });
 }
 
+//Classifies all cards based on their rarity and saves them
+//in groups inside cards_by_rarity with the following format:
+//{
+//  rarity1: [{"Rarity Folder": rarity1, "Filename": "Name of Card", ...}, card2, card3, ..., cardN],
+//  rarity2: [...],
+//  rarity3: [...],
+//  ...
+//  rarityN: [...]
+// }
 function getCardsByRarity() {
   cards_by_rarity = cards_data.reduce((result, card) => {
     result[card["Rarity Folder"]] = [
@@ -48,11 +58,11 @@ async function main() {
           pullAndRenderCards(cards_data, COLLECTIONS_MAIN_CONTENT);
         await setupDetailsDialog();
         break;
+
       case "/collection.html":
         await setupDetailsDialog();
         renderCards(cards_data, COLLECTIONS_MAIN_CONTENT);
     }
-    getCardsByRarity();
   });
 }
 

--- a/pages/collection.html
+++ b/pages/collection.html
@@ -58,17 +58,6 @@
           Github</a
         >
       </footer>
-      <div
-        role="dialog"
-        aria-modal="true"
-        id="card-details-dialog"
-        class="hidden"
-      >
-        <button id="card-details-dialog-close">Close</button>
-        <div class="dialog-title"></div>
-        <img class="details-dialog-card" />
-        <section class="details-dialog-text"></section>
-      </div>
     </main>
 
     <!-- Javascript must be at end so it can access the loaded DOM -->


### PR DESCRIPTION
Pokemon TCG packs use the concept of "slots"; these slots determine what kind of rarity can be found at a determined position when opening the pack. For example, the 1st slot may contain only common cards, the 2nd common and uncommon cards, and so on. This PR implements facilities to declare slots along with the probabilities for each rarity in each slot, along with a debug function (testRates) to check the average probabilities to get each rarity over time. 

With this we can also "nudge" rates a little to boost rarer cards should the need arise; this only works with rarities at the time, to do the same with individual cards (Reward a new card on X duplicates for example, like a pity system of sorts) it would be in a different PR.