### PR TITLE
Add page size dropdown and card titles in collection page.

### DIFF
--- a/card.html
+++ b/card.html
@@ -1,6 +1,7 @@
 <div class="card">
   <button class="card-front">
     <img class="card-image" />
+    <!--If the card renders with a subtitle it will show here as a p element with class "card-subtitle"-->
   </button>
   <button class="card-back hidden">
     <img src="../images/elysium_delivery_services.jpg" class="card-cover" />

--- a/css/card.css
+++ b/css/card.css
@@ -47,6 +47,10 @@
   grid-area: x;
 }
 
+.card-subtitle {
+  user-select: text;
+}
+
 #card-details-dialog {
   top: 2rem;
   left: 50vw; /* move to the middle of the screen (assumes relative parent is the body/viewport) */

--- a/js/cards.js
+++ b/js/cards.js
@@ -75,13 +75,7 @@ export async function defineCardComponent() {
         this.flipCard();
       }
       if (this.getAttribute("show_title") === "true") {
-        this.front.insertAdjacentHTML(
-          "beforeend",
-          `<p class="card-subtitle">${this.data["Collector Number"].padStart(
-            3,
-            "0"
-          )} ${this.data["Card Display Name"]}</p>`
-        );
+        this.showSubtitle();
       }
     }
 
@@ -105,6 +99,16 @@ export async function defineCardComponent() {
     showDetails() {
       updateDetailsDialog(this.data, this.getImageURL());
       DETAILS_DIALOG_A11Y.show();
+    }
+
+    showSubtitle() {
+      this.front.insertAdjacentHTML(
+        "beforeend",
+        `<p class="card-subtitle">${this.data["Collector Number"].padStart(
+          3,
+          "0"
+        )} ${this.data["Card Display Name"]}</p>`
+      );
     }
   }
   customElements.define("tcg-card", Card);

--- a/js/cards.js
+++ b/js/cards.js
@@ -74,6 +74,15 @@ export async function defineCardComponent() {
       if (CARD_ART_HIDDEN_ON_LOAD) {
         this.flipCard();
       }
+      if (this.getAttribute("show_title") === "true") {
+        this.front.insertAdjacentHTML(
+          "beforeend",
+          `<p class="card-subtitle">${this.data["Collector Number"].padStart(
+            3,
+            "0"
+          )} ${this.data["Card Display Name"]}</p>`
+        );
+      }
     }
 
     //Returns an url of the form:
@@ -104,14 +113,19 @@ export async function defineCardComponent() {
 //Renders a list of cards in the element specified in htmlLocation.
 //If replace is true, overwrites all elements inside htmlLocation.
 //else, adds the cards to the rest of the inner content.
-export function renderCards(cards, htmlLocation, replace = false) {
+export function renderCards(
+  cards,
+  htmlLocation,
+  replace = false,
+  show_title = false
+) {
   if (replace) {
     htmlLocation.innerHTML = "";
   }
   for (let i = 0; i < cards.length; i++) {
     htmlLocation.insertAdjacentHTML(
       "beforeend",
-      `<tcg-card card-id="${cards[i]["Collector Number"]}"></tcg-card>`
+      `<tcg-card card-id="${cards[i]["Collector Number"]}" show_title="${show_title}"></tcg-card>`
     );
   }
 }
@@ -200,5 +214,5 @@ export function showCollection(cards_data, htmlLocation, page = 1) {
     //If we don't need pagination, we hide the controls.
     PAGINATION_BTNS.container.classList.add("hidden");
   }
-  renderCards(cards, htmlLocation, true);
+  renderCards(cards, htmlLocation, true, true);
 }

--- a/js/cards.js
+++ b/js/cards.js
@@ -82,7 +82,7 @@ export async function defineCardComponent() {
     //Returns an url of the form:
     //`https://res.cloudinary.com/${CLOUD_NAME}/image/upload/${RARITY}/${FILENAME}.png`
     getImageURL() {
-      return `${CLOUDINARY_URL}${this.data["Rarity Folder"]}/${this.data["Filename"]}.png`;
+      return `${CLOUDINARY_URL}/q_auto/${this.data["Rarity Folder"]}/${this.data["Filename"]}.png`;
     }
 
     flipCard() {

--- a/js/main.js
+++ b/js/main.js
@@ -12,7 +12,8 @@ const FULL_COLLECTION_TOGGLE = document.getElementById(
   "full-collection-toggle"
 );
 const RESET_COLLECTION = document.getElementById("reset-collection");
-const SORT_DROPDOWN = document.getElementById("sort-dropdown")
+const SORT_DROPDOWN = document.getElementById("sort-dropdown");
+const CARDS_PER_PAGE_DROPDOWN = document.getElementById("size-dropdown");
 
 export const CARD_ART_HIDDEN_ON_LOAD =
   PAGES_WHERE_CARD_HIDDEN.includes(CURRENT_PAGE);
@@ -85,14 +86,22 @@ async function main() {
         RESET_COLLECTION.onclick = (event) => {
           localStorage.clear();
           localStorage.setItem("fullCollection", "true");
-          localStorage.setItem("sort", SORT_DROPDOWN.value)
+          localStorage.setItem("sort", SORT_DROPDOWN.value);
+          localStorage.setItem("page-size", CARDS_PER_PAGE_DROPDOWN.value);
           toggleCollection();
         };
         SORT_DROPDOWN.onchange = (event) => {
-          localStorage.setItem("sort", event.target.value)
-          showCollection(cards_data, COLLECTIONS_MAIN_CONTENT)
-        }
-        SORT_DROPDOWN.value = localStorage.getItem("sort") ?? "Collector Number"
+          localStorage.setItem("sort", event.target.value);
+          showCollection(cards_data, COLLECTIONS_MAIN_CONTENT);
+        };
+        SORT_DROPDOWN.value =
+          localStorage.getItem("sort") ?? "Collector Number";
+        CARDS_PER_PAGE_DROPDOWN.onchange = (event) => {
+          localStorage.setItem("page-size", event.target.value);
+          showCollection(cards_data, COLLECTIONS_MAIN_CONTENT);
+        };
+        CARDS_PER_PAGE_DROPDOWN.value =
+          localStorage.getItem("page-size") ?? "10";
     }
   });
 }

--- a/pages/collection.html
+++ b/pages/collection.html
@@ -82,18 +82,27 @@
             Sort by:
             <select id="sort-dropdown">
                 <option value="Collector Number" selected>Collector Number</option>
+                <option value="Collector Number-">Collector Number (Reverse)</option>
                 <option value="Rarity">Rarity</option>
                 <option value="Rarity-">Rarity (Reverse)</option>
             </select>
         </label>
+        <label>
+          Page size:
+          <select id="size-dropdown">
+            <option value="10" selected>10</option>
+            <option value="20">20</option>
+            <option value="50">50</option>
+            <option value="all">All</option>
+          </select>
+        </label>
 
         <p id="collected-cards-number">Collected cards:</p>
         <section id="card-list"></section>
-        <div id="collection-pagination">
-          <p id="pagination-total"></p>
-          <a id="pagination-previous" href="javascript:void(0)" class="hidden">Previous</a>
-          <a id="pagination-current" href="javascript:void(0)">1</a>
-          <a id="pagination-next" href="javascript:void(0)">Next</a>
+        <div id="collection-pagination" class="hidden">
+          <button id="pagination-previous" class="hidden">Previous</button>
+          <button id="pagination-current">1</button>
+          <button id="pagination-next">Next</button>
         </div>
       </section>
 

--- a/pages/collection.html
+++ b/pages/collection.html
@@ -101,7 +101,7 @@
         <section id="card-list"></section>
         <div id="collection-pagination" class="hidden">
           <button id="pagination-previous" class="hidden">Previous</button>
-          <button id="pagination-current">1</button>
+          <span id="pagination-current">1</span>
           <button id="pagination-next">Next</button>
         </div>
       </section>


### PR DESCRIPTION
Fairly small PR (ignoring Prettier doing its thing):

- Creates a page size dropdown for showing 10, 20, 50 or all cards per page.
- Shows card number and title below each card in the collection page.
- Adds Collector Number (Reverse) to sort dropdown. (Only 1 line of code)
- Changed pagination controls from "a" to "button", and moved it all into 1 line.

I wanted to get this out of the way to focus on making collections.js next.