### PR TITLE
Gacha accessibility

### DIFF
--- a/card.html
+++ b/card.html
@@ -3,7 +3,7 @@
     <div class="card-image"></div>
     <!--If the card renders with a subtitle it will show here as a p element with class "card-subtitle"-->
   </button>
-  <button class="card-back hidden">
+  <button aria-label="unflipped card" class="card-back hidden">
     <div class="card-cover"></div>
   </button>
 </div>

--- a/card.html
+++ b/card.html
@@ -1,9 +1,12 @@
 <div class="card-component">
   <button class="card-front">
     <div class="card-image"></div>
-    <!--If the card renders with a subtitle it will show here as a p element with class "card-subtitle"-->
   </button>
   <button aria-label="unflipped card" class="card-back hidden">
     <div class="card-cover"></div>
   </button>
 </div>
+<!--  aria-hidden since the card has its own aria-label with the same contents
+      aria-labelledby is usually ideal, but would require more work to implement
+      successfully in our complex show/ hiding behavior -->
+<span aria-hidden="true" class="card-subtitle"></span>

--- a/css/card.css
+++ b/css/card.css
@@ -43,8 +43,13 @@ tcg-card {
   right: 10%;
   transition: transform 0.3s ease; /* make any changes to this card flow, so it doesn't snap */
 }
-tcg-card .card-subtitle {
+.card-subtitle {
   color: white;
+  user-select: text;
+}
+#pile-pull-announcement {
+  margin: 0;
+  text-align: center;
 }
 
 /* rotate card differently depending on its position in the pile */
@@ -221,10 +226,6 @@ tcg-card .card-subtitle {
   right: 1em;
 }
 
-.card-subtitle {
-  user-select: text;
-}
-
 #sort-dropdown {
   text-align: center;
   margin-left: 4px;
@@ -235,7 +236,7 @@ section label {
 }
 
 #gacha-button {
-  margin-top: 1em;
+  margin-bottom: 1em;
   background-color: var(--accent-color);
 }
 

--- a/css/card.css
+++ b/css/card.css
@@ -109,13 +109,13 @@ tcg-card {
   animation: left 1s ease 0s 1;
   animation-fill-mode: forwards;
 }
-#gacha-controls tcg-card.clicked:nth-child(3n + 1) {
+#gacha-controls.pile-display tcg-card.clicked:nth-child(3n + 1) {
   --rotation: -3deg;
 }
-#gacha-controls tcg-card.clicked:nth-child(3n + 2) {
+#gacha-controls.pile-display tcg-card.clicked:nth-child(3n + 2) {
   --rotation: 5deg;
 }
-#gacha-controls tcg-card.clicked:nth-child(3n + 3) {
+#gacha-controls.pile-display tcg-card.clicked:nth-child(3n + 3) {
   --rotation: 0deg;
 }
 

--- a/css/card.css
+++ b/css/card.css
@@ -47,7 +47,8 @@ tcg-card {
   color: white;
   user-select: text;
 }
-#pile-pull-announcement {
+#pull-announcement {
+  color: white;
   margin: 0;
   text-align: center;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -5,7 +5,7 @@
 :root {
   --accent-color: #54acdc;
   --accent-color-lighten-50: #a9d5ed;
-  --bg-color: #1D346D;
+  --bg-color: #1d346d;
   --bg-color-lighten-50: #6c8bd7;
 }
 
@@ -19,7 +19,8 @@ html {
   height: 100%;
 }
 
-body, main {
+body,
+main {
   background: transparent;
 }
 
@@ -75,6 +76,10 @@ select:hover,
 button:not(.card-front):not(.card-back):focus-visible,
 select:focus-visible {
   background-color: var(--accent-color);
+}
+
+.skip-link {
+  color: white;
 }
 
 #size-dropdown {

--- a/js/cards.js
+++ b/js/cards.js
@@ -36,8 +36,8 @@ export async function defineCardComponent() {
       this.image = this.getElementsByClassName("card-image")[0];
       this.image.style.backgroundImage = 'url("' + this.getImageURL() + '")';
       this.image.classList.add(setCardRarity(this.data["Rarity Folder"]));
-      this.addCardSubtitle();
       this.subtitle = this.getElementsByClassName("card-subtitle")[0];
+      this.subtitle.textContent = this.getSubtitleText();
       this.setupOnClickEvents();
       if (CARD_ART_HIDDEN_ON_LOAD) {
         this.setupCardForGacha();
@@ -88,8 +88,6 @@ export async function defineCardComponent() {
           this.getSubtitleText();
       } else {
         this.subtitle.classList.remove("hidden");
-        // Set aria-live on parent container to announce subtitle text when it appears
-        this.setAttribute("aria-live", "polite");
       }
     }
 
@@ -111,14 +109,6 @@ export async function defineCardComponent() {
       return `${this.data["Collector Number"].padStart(3, "0")} ${
         this.data["Card Display Name"]
       } (${this.data["Rarity Folder"]})`;
-    }
-
-    addCardSubtitle() {
-      // aria-hidden since the card has its own aria-label handling
-      this.insertAdjacentHTML(
-        "beforeend",
-        `<span aria-hidden="true" class="card-subtitle">${this.getSubtitleText()}</span>`
-      );
     }
   }
   customElements.define("tcg-card", Card);

--- a/js/cards.js
+++ b/js/cards.js
@@ -54,17 +54,23 @@ export async function defineCardComponent() {
       // The back of the card is automatically hidden for the collections page
       // We have to reset it for the gacha so that it can be clicked on
       this.back.classList.remove("hidden");
-      // Prevent the front from being tabbed on, so that you don't need to tab twice per card
+      // With card back shown, make card front inaccessible, just like it is for mouse users
       this.front.tabIndex = "-1";
+      this.front.setAttribute("aria-hidden", "true");
     }
 
     flipCard() {
       // update the next value for the zIndex
       card_z_index++;
 
-      // register this as a clicked card, and add the class to animate to flip over
+      // register as a clicked card, add class to animate flip-over, and make card front accessible again
       this.classList.add("clicked");
       this.holder.classList.add("flip");
+      this.front.removeAttribute("tabindex");
+      this.front.removeAttribute("aria-hidden");
+      this.front.setAttribute("aria-label", this.getSubtitleText());
+      this.back.tabIndex = "-1";
+      this.back.setAttribute("aria-hidden", "true");
 
       // Start the animation and update the z-index when the animation starts
       // This is to stack any opened cards in the reverse order
@@ -188,6 +194,8 @@ export function removeUnclickableFromCards() {
   let clickedCard = document.getElementsByClassName("opened");
   for (let i = 0; i < clickedCard.length; i++) {
     clickedCard[i].classList.remove("unclickable");
+    clickedCard[i].parentElement.removeAttribute("tabindex");
+    clickedCard[i].parentElement.removeAttribute("aria-hidden");
   }
 }
 export function addUnclickableToCardsExceptLast() {
@@ -204,6 +212,8 @@ export function addUnclickableToCardsExceptLast() {
       // while the unmatching ones are beneath the most recently flipped card, so should have any unclickable class removed
       if (parseInt(z) !== card_z_index) {
         clickedCard[i].classList.add("unclickable");
+        clickedCard[i].parentElement.tabIndex = "-1";
+        clickedCard[i].parentElement.setAttribute("aria-hidden", "true");
       } else {
         clickedCard[i].classList.remove("unclickable");
       }

--- a/js/cards.js
+++ b/js/cards.js
@@ -31,6 +31,7 @@ export async function defineCardComponent() {
       this.innerHTML = html;
       this.holder = this.getElementsByClassName("card-component")[0];
       this.front = this.getElementsByClassName("card-front")[0];
+      this.front.setAttribute("aria-label", this.getSubtitleText());
       this.back = this.getElementsByClassName("card-back")[0];
       this.image = this.getElementsByClassName("card-image")[0];
       this.image.style.backgroundImage = 'url("' + this.getImageURL() + '")';
@@ -68,7 +69,6 @@ export async function defineCardComponent() {
       this.holder.classList.add("flip");
       this.front.removeAttribute("tabindex");
       this.front.removeAttribute("aria-hidden");
-      this.front.setAttribute("aria-label", this.getSubtitleText());
       this.back.tabIndex = "-1";
       this.back.setAttribute("aria-hidden", "true");
 
@@ -114,9 +114,10 @@ export async function defineCardComponent() {
     }
 
     addCardSubtitle() {
+      // aria-hidden since the card has its own aria-label handling
       this.insertAdjacentHTML(
         "beforeend",
-        `<span class="card-subtitle">${this.getSubtitleText()}</span>`
+        `<span aria-hidden="true" class="card-subtitle">${this.getSubtitleText()}</span>`
       );
     }
   }

--- a/js/cards.js
+++ b/js/cards.js
@@ -71,6 +71,9 @@ export async function defineCardComponent() {
       this.front.removeAttribute("aria-hidden");
       this.back.tabIndex = "-1";
       this.back.setAttribute("aria-hidden", "true");
+      // have screenreader announce the card name
+      document.getElementById("pull-announcement").textContent =
+        this.getSubtitleText();
 
       // Start the animation and update the z-index when the animation starts
       // This is to stack any opened cards in the reverse order
@@ -84,8 +87,6 @@ export async function defineCardComponent() {
       // remove the previous hover effects only if the gacha is not displayed as a grid
       if (gacha_display_selection !== "gacha-grid") {
         this.addEventListener("animationend", addUnclickableToCardsExceptLast);
-        document.getElementById("pull-announcement").textContent =
-          this.getSubtitleText();
       } else {
         this.subtitle.classList.remove("hidden");
       }

--- a/js/cards.js
+++ b/js/cards.js
@@ -84,7 +84,7 @@ export async function defineCardComponent() {
       // remove the previous hover effects only if the gacha is not displayed as a grid
       if (gacha_display_selection !== "gacha-grid") {
         this.addEventListener("animationend", addUnclickableToCardsExceptLast);
-        document.getElementById("pile-pull-announcement").textContent =
+        document.getElementById("pull-announcement").textContent =
           this.getSubtitleText();
       } else {
         this.subtitle.classList.remove("hidden");
@@ -155,10 +155,10 @@ export function updateGachaView(e) {
     GACHA_SECTION.classList.remove("pile-display");
     // we want all cards to be clickable now
     removeUnclickableFromCards();
-    // card subtitles will appear directly below cards in grid view
-    if (document.getElementById("pile-pull-announcement")) {
-      document.getElementById("pile-pull-announcement").remove();
-    }
+    // hide visually since flipped cards will have subtitle below them
+    document
+      .getElementById("pull-announcement")
+      .classList.add("visually-hidden");
     // only show subtitle on flipped cards
     Array.from(document.getElementsByClassName("clicked")).forEach(
       (element) => {
@@ -178,15 +178,10 @@ export function updateGachaView(e) {
         element.classList.add("hidden");
       }
     );
-    // add card pull name live announcement container below card pile
-    if (!document.getElementById("pile-pull-announcement")) {
-      document
-        .getElementById("card-list")
-        .insertAdjacentHTML(
-          "beforebegin",
-          `<p aria-live="polite" id="pile-pull-announcement" class="card-subtitle"></p>`
-        );
-    }
+    // show pull announcement text visually since cards will not have subtitles below them
+    document
+      .getElementById("pull-announcement")
+      .classList.remove("visually-hidden");
   }
 }
 export function removeUnclickableFromCards() {

--- a/js/gacha.js
+++ b/js/gacha.js
@@ -145,7 +145,7 @@ function getRandomCards(cards, n) {
 }
 
 //Pulls cards from the cards_data array and renders them in render_location.
-export function pullAndRenderCards(cards_data, render_location) {
+export function pullAndRenderCards(render_location) {
   let pulled = pullCards(slots);
   renderCards(pulled, render_location, true);
 }

--- a/js/gacha.js
+++ b/js/gacha.js
@@ -148,6 +148,10 @@ function getRandomCards(cards, n) {
 export function pullAndRenderCards(render_location) {
   let pulled = pullCards(slots);
   renderCards(pulled, render_location, true);
+  render_location.insertAdjacentHTML(
+    "beforeend",
+    `<span class="visually-hidden">No more cards in this pack</span>`
+  );
 }
 
 //Debug function to get the average rates for each rarity over a list of pulls.

--- a/js/main.js
+++ b/js/main.js
@@ -119,7 +119,7 @@ async function main() {
         }
 
         GACHA_BUTTON.onclick = (event) =>
-          pullAndRenderCards(cards_data, COLLECTIONS_MAIN_CONTENT);
+          pullAndRenderCards(COLLECTIONS_MAIN_CONTENT);
         break;
 
       case "/collection.html":

--- a/pages/artist-writer-board.html
+++ b/pages/artist-writer-board.html
@@ -41,7 +41,9 @@
     <main>
       <h1 id="title-header">The Regis Altare Birthday Project 2023</h1>
 
-      <a href="#artist-writer-board" class="visually-hidden">Skip to content</a>
+      <a href="#artist-writer-board" class="visually-hidden skip-link"
+        >Skip to content</a
+      >
 
       <!-- Inverted border radius for clip-path -->
       <svg width="0" height="0" aria-hidden="true">

--- a/pages/collection.html
+++ b/pages/collection.html
@@ -41,7 +41,7 @@
     <main>
       <h1 id="title-header">The Regis Altare Birthday Project 2023</h1>
 
-      <a href="#card-list" class="visually-hidden">Skip to content</a>
+      <a href="#card-list" class="visually-hidden skip-link">Skip to content</a>
 
       <!-- Inverted border radius for clip-path -->
       <svg width="0" height="0" aria-hidden="true">

--- a/pages/credits.html
+++ b/pages/credits.html
@@ -41,7 +41,7 @@
     <main>
       <h1 id="title-header">The Regis Altare Birthday Project 2023</h1>
 
-      <a href="#credits" class="visually-hidden">Skip to content</a>
+      <a href="#credits" class="visually-hidden skip-link">Skip to content</a>
 
       <!-- Inverted border radius for clip-path -->
       <svg width="0" height="0" aria-hidden="true">

--- a/pages/gacha.html
+++ b/pages/gacha.html
@@ -155,6 +155,7 @@
           </p>
         </div>
         <button id="gacha-button" type="submit">Open Card Pack</button>
+        <p aria-live="polite" id="pull-announcement"></p>
         <section id="card-list">
           Ain't nobody here but us Altventurers. Pull the gacha to get started!
         </section>

--- a/pages/gacha.html
+++ b/pages/gacha.html
@@ -41,7 +41,9 @@
     <main>
       <h1 id="title-header">The Regis Altare Birthday Project 2023</h1>
 
-      <a href="#gacha-controls" class="visually-hidden">Skip to content</a>
+      <a href="#gacha-controls" class="visually-hidden skip-link"
+        >Skip to content</a
+      >
 
       <!-- Inverted border radius for clip-path -->
       <svg width="0" height="0" aria-hidden="true">

--- a/pages/gacha.html
+++ b/pages/gacha.html
@@ -164,8 +164,7 @@
           </p>
         </div>
         <button id="gacha-button" type="submit">Open Card Pack</button>
-        <!-- block screenreaders from focusing on the announcement text -->
-        <p aria-live="polite" aria-hidden="true" id="pull-announcement"></p>
+        <p aria-live="polite" id="pull-announcement"></p>
         <section id="card-list">
           Ain't nobody here but us Altventurers. Pull the gacha to get started!
         </section>

--- a/pages/gacha.html
+++ b/pages/gacha.html
@@ -67,7 +67,14 @@
       <!-- Navigation -->
       <nav>
         <a id="nav-home" href="../index.html">
-          <object class="icon icon-logo" type="image/svg+xml" aria-hidden="true" data="../icons/Icons_Logo.svg" tabindex="-1" tabindex="-1">
+          <object
+            class="icon icon-logo"
+            type="image/svg+xml"
+            aria-hidden="true"
+            data="../icons/Icons_Logo.svg"
+            tabindex="-1"
+            tabindex="-1"
+          >
             <img src="../icons/Icons_Logo.svg" />
           </object>
           <span>Home</span>
@@ -125,7 +132,7 @@
             src="../icons/Icons_Close.svg"
           />
         </button>
-    </nav>
+      </nav>
 
       <section id="gacha-controls">
         <form>
@@ -157,7 +164,8 @@
           </p>
         </div>
         <button id="gacha-button" type="submit">Open Card Pack</button>
-        <p aria-live="polite" id="pull-announcement"></p>
+        <!-- block screenreaders from focusing on the announcement text -->
+        <p aria-live="polite" aria-hidden="true" id="pull-announcement"></p>
         <section id="card-list">
           Ain't nobody here but us Altventurers. Pull the gacha to get started!
         </section>

--- a/pages/gacha.html
+++ b/pages/gacha.html
@@ -145,6 +145,9 @@
           <label for="gacha-grid"> Card Grid</label>
         </form>
         <div id="gacha-notes">
+          <p class="visually-hidden">
+            Card Grid is the recommended view for screenreader users.
+          </p>
           <p>View the details of your opened cards in your Collection.</p>
           <p>
             When the card has stopped moving, animate it again by clicking /

--- a/pages/gacha.html
+++ b/pages/gacha.html
@@ -144,7 +144,6 @@
           />
           <label for="gacha-grid"> Card Grid</label>
         </form>
-        <button id="gacha-button" type="submit">Open Card Pack</button>
         <div id="gacha-notes">
           <p>View the details of your opened cards in your Collection.</p>
           <p>
@@ -152,6 +151,7 @@
             hovering!
           </p>
         </div>
+        <button id="gacha-button" type="submit">Open Card Pack</button>
         <section id="card-list">
           Ain't nobody here but us Altventurers. Pull the gacha to get started!
         </section>

--- a/pages/message-board.html
+++ b/pages/message-board.html
@@ -41,7 +41,9 @@
     <main>
       <h1 id="title-header">The Regis Altare Birthday Project 2023</h1>
 
-      <a href="#message-board" class="visually-hidden">Skip to content</a>
+      <a href="#message-board" class="visually-hidden skip-link"
+        >Skip to content</a
+      >
 
       <!-- Inverted border radius for clip-path -->
       <svg width="0" height="0" aria-hidden="true">


### PR DESCRIPTION
 - Moved button down a bit closer to the card pile section
 - Added rarity to card subtitle
 - Show subtitle on flipped cards: for pile, show it at the top (showing it under the card would slant it in the direct of the card). for grid, show directly under card
 - Screenreader compatibility for gacha game

This video shows:
 - The card grid recommendation note, and me setting it to card grid
 - Flipping over cards
 - re-focusing on already flipped cards
 - the "no more cards" message if you reach the end of the card list

https://user-images.githubusercontent.com/47371080/211174180-27f1c36e-8c36-41f9-bdd4-73ad5b489bc8.mov
