### PR TITLE
Gacha and Collections - Contributor QA Fixes

### DIFF
--- a/css/card.css
+++ b/css/card.css
@@ -1249,18 +1249,21 @@ card will still fly across the screen, or flip when opened */
   animation-fill-mode: forwards;
 }
 
-/* for any additional text on the gacha page */
-#gacha-notes {
+/* for any additional text on the gacha and collections page */
+#gacha-notes, #collection-notes {
   color: white;
   background-color: transparent;
   margin: 1em 0;
   font-size: 1em;
 }
-#gacha-notes p {
+#gacha-notes p, #collection-notes p {
   margin: 0.3em 0;
 }
 
 /* for any additional text on the collections page */
+#collection-notes {
+  color: black;
+}
 #collection-foreword {
   text-align: right;
   font-size: 1em;

--- a/css/card.css
+++ b/css/card.css
@@ -294,6 +294,8 @@ section label {
   margin-bottom: 1em;
   background-color: var(--accent-color);
   animation: button-wiggle 2.32s ease 0s infinite;
+  /* ensure the button does not wrap outside of the button area */
+  white-space: nowrap;
 }
 .pile-display button.gacha-button {
   margin-bottom: 0.5em;
@@ -803,6 +805,10 @@ section#gacha-controls fieldset:nth-child(3) {
     /* card height is calculated by measurement in Photoshop */
     --card-width: 200px;
     --card-height: 279px;
+  }
+  #gacha-controls button.gacha-button {
+    /* ensure the button is not too small */
+    font-size: 0.8em;
   }
 }
 

--- a/css/card.css
+++ b/css/card.css
@@ -811,9 +811,10 @@ section#gacha-controls fieldset:nth-child(3) {
     --card-width: 200px;
     --card-height: 279px;
   }
-  #gacha-controls button.gacha-button {
-    /* ensure the button is not too small */
-    font-size: 0.8em;
+  #gacha-controls.grid-display button.gacha-button {
+    /* ensure the button is not too small, only for grid display though */
+    font-size: 0.9em;
+    border-width: 9px 2px;
   }
 }
 

--- a/css/card.css
+++ b/css/card.css
@@ -770,6 +770,11 @@ section#gacha-controls fieldset:nth-child(3) {
     display: block;
     width: 100%;
   }
+  #collection-border {
+    /* make it smaller again at this point, for small phones */
+    --card-width: 200px;
+    --card-height: 279px;
+  }
   .details-dialog-card {
     /* adjust the card size further in the dialog depending on the screen size - probably a better way to do it*/
     width: calc(var(--card-width) * 1.5);

--- a/css/main.css
+++ b/css/main.css
@@ -129,6 +129,11 @@ input:focus-visible {
   background-color: var(--accent-color);
 }
 
+/* make this look more like a warning */
+#reset-collection:hover {
+  background-color: rgb(114, 0, 0);
+}
+
 fieldset {
   border: none;
   padding: 0;

--- a/js/gacha.js
+++ b/js/gacha.js
@@ -206,8 +206,22 @@ export function pullAndRenderCards(render_location) {
     "aria-labelledby",
     "roll-again-prompt gacha-button-roll-again"
   );
-  gachaRollAgainButton.onclick = (event) =>
+  gachaRollAgainButton.onclick = (event) =>{
+    // if in a grid display, scroll to the top
+    if(document.getElementById("gacha-grid").checked){
+      // check if on a narrow screen or not
+      if(innerWidth < 480){
+        // scroll just to the top of the section if on a phone
+        let sectionDistanceFromTop = window.pageYOffset + document.getElementById("gacha-controls").getBoundingClientRect().top;
+        window.scrollTo(0, sectionDistanceFromTop);
+      } else {
+        // scroll to the very top of the page if on a computer (likely more space to work with)
+        window.scrollTo(0, 0);
+      }
+    }
+    // then pull cards again
     pullAndRenderCards(document.getElementById("card-list"));
+  }
 
   gachaRollAgain.append(gachaRollAgainButton);
   render_location.append(gachaRollAgain);

--- a/js/main.js
+++ b/js/main.js
@@ -90,7 +90,7 @@ function setupCollectionControls() {
     FULL_COLLECTION_TOGGLE.textContent = "Hide Full Collection";
   }
   RESET_COLLECTION.onclick = (event) => {
-    var confirmReset = window.confirm("Do you want to clear your entire collection?\nSelect OK to clear now, or Cancel to stop.\nIf using a keyboard: use Enter to clear now, or Esc to stop.");
+    var confirmReset = window.confirm("Do you want to clear your entire collection?\nSelect OK to clear now, or Cancel to stop.\nIf using a keyboard: use Enter to clear now, or Escape to stop.");
     if(confirmReset){
       localStorage.clear();
       localStorage.setItem("showFullCollection", "true");

--- a/js/main.js
+++ b/js/main.js
@@ -90,11 +90,14 @@ function setupCollectionControls() {
     FULL_COLLECTION_TOGGLE.textContent = "Hide Full Collection";
   }
   RESET_COLLECTION.onclick = (event) => {
-    localStorage.clear();
-    localStorage.setItem("showFullCollection", "true");
-    localStorage.setItem("sort", SORT_DROPDOWN.value);
-    localStorage.setItem("page-size", CARDS_PER_PAGE_DROPDOWN.value);
-    toggleCollection();
+    var confirmReset = window.confirm("Do you want to clear your entire collection?\nSelect OK to clear now, or Cancel to stop.\nIf using a keyboard: use Enter to clear now, or Esc to stop.");
+    if(confirmReset){
+      localStorage.clear();
+      localStorage.setItem("showFullCollection", "true");
+      localStorage.setItem("sort", SORT_DROPDOWN.value);
+      localStorage.setItem("page-size", CARDS_PER_PAGE_DROPDOWN.value);
+      toggleCollection();
+    }
   };
 
   SEARCH_BAR.onchange = (event) =>

--- a/js/main.js
+++ b/js/main.js
@@ -90,7 +90,9 @@ function setupCollectionControls() {
     FULL_COLLECTION_TOGGLE.textContent = "Hide Full Collection";
   }
   RESET_COLLECTION.onclick = (event) => {
+    // confirm if they want to clear first using a js dialog
     var confirmReset = window.confirm("Do you want to clear your entire collection?\nSelect OK to clear now, or Cancel to stop.\nIf using a keyboard: use Enter to clear now, or Escape to stop.");
+    // if OK is clicked, then proceed as normal
     if(confirmReset){
       localStorage.clear();
       localStorage.setItem("showFullCollection", "true");
@@ -98,6 +100,7 @@ function setupCollectionControls() {
       localStorage.setItem("page-size", CARDS_PER_PAGE_DROPDOWN.value);
       toggleCollection();
     }
+    // nothing happens if cancel is clicked
   };
 
   SEARCH_BAR.onchange = (event) =>

--- a/pages/collection.html
+++ b/pages/collection.html
@@ -175,6 +175,10 @@
           </label>
         </section>
 
+        <div id="collection-notes">
+          <p>Click into any card below to see it enlarged and read any extended lore!</p>
+        </div>
+
         <div id="collection-foreword" class="hidden">
           <p><strong>Disclaimer:</strong> The cards in our lovingly fan-curated RegIsekai deck run on pure creativity, and are not regulated or balanced for play. The unplayability is an artistic choice to reflect the chaotic evil of the Demon God King Regis himself, and definitely not because balancing a playable TCG is really, really hard.</p>
           <p>I mean… you can still <em>try</em> to play it, but a mald-free experience is far from guaranteed.</p>


### PR DESCRIPTION
Issues/Suggestions raised so far: 
- Explanation text on how to use the Collections page (under buttons, above foreword/disclaimer)
- Reset card button includes a confirmation, so will not be accidentally cleared (tested with VoiceOver on Mac)
- Reset card button also made to be a dark red on hover to try and highlight it as possibly a bad thing.
- Gacha roll again button adjusted so text doesn't wrap out when viewing on a mobile display (300px or less)
- Gacha: if rolling in grid mode, re-roll action will also scroll back to the top of the page

Suggestion not yet addressed:
- Open all cards option in the gacha, for mobile users